### PR TITLE
Add a missing return

### DIFF
--- a/lib/pgroonga-benchmark/processor.rb
+++ b/lib/pgroonga-benchmark/processor.rb
@@ -35,6 +35,7 @@ module PGroongaBenchmark
         @config.postgresql.open_connection(**options) do |connection|
           execute_sql(connection, sql, &block)
         end
+        return
       end
 
       test_crash_safe = true if test_crash_safe.nil?


### PR DESCRIPTION
Because the procedure when test_crash_safe in config.yml is valid
works even if test_crash_safe in config.yml is nil