### PR TITLE
enable user_install

### DIFF
--- a/ansible/almalinux-8-primary/playbook.yml
+++ b/ansible/almalinux-8-primary/playbook.yml
@@ -183,7 +183,6 @@
     - name: Install Ruby libraries
       become_user: vagrant
       bundler:
-        user_install: false
         chdir: /vagrant
       vars:
         ansible_ssh_pipelining: true


### PR DESCRIPTION
Because we can't use pg and ffi when these gems install with bundler.
The default value of user_install is true.