### PR TITLE
Gemfile: add gem benchmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org/"
 
+gem "benchmark"
 gem "faker"
 gem "groonga-synonym"
 gem "natto"


### PR DESCRIPTION
Because gem `benchmark` will be migrated from default gems to bundled gems at Ruby 3.5.
ref: https://bugs.ruby-lang.org/issues/20309

This change will suppress the following warning.
```
/home/runner/work/pgroonga/pgroonga/pgroonga-benchmark/lib/pgroonga-benchmark/processor.rb:1: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```